### PR TITLE
Bump max tries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-zendesk"
-version = "0.1.0"
+version = "0.1.1"
 description = "`tap-zendesk` is a Singer tap for Zendesk, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Mahangu Weerasinghe <mahangu@gmail.com>"]

--- a/tap_zendesk/client.py
+++ b/tap_zendesk/client.py
@@ -228,6 +228,9 @@ class IncrementalZendeskStream(ZendeskStream):
             else IncrementalTimeBasedPaginator()
         )
 
+    def backoff_max_tries(self) -> int:
+        return 10
+
 
 class CursorPaginator(BaseHATEOASPaginator):
     def get_next_url(self, response: Response) -> str:

--- a/tap_zendesk/client.py
+++ b/tap_zendesk/client.py
@@ -229,6 +229,11 @@ class IncrementalZendeskStream(ZendeskStream):
         )
 
     def backoff_max_tries(self) -> int:
+        """The number of attempts before giving up when retrying requests.
+
+        Returns:
+            Number of max retries.
+        """
         return 10
 
 


### PR DESCRIPTION
Some endpoints, such as GET /api/v2/incremental/*, have lower rate limits ([reference](https://developer.zendesk.com/api-reference/introduction/rate-limits/#endpoint-rate-limits)). This PR increases the number of retry attempts to reduce the likelihood of encountering 429 Client Error: Too Many Requests.